### PR TITLE
Fixes: error: unknown type name 'in_addr_t' in_addr_t inet_addr(const char* __s);

### DIFF
--- a/libc/include/netinet/in.h
+++ b/libc/include/netinet/in.h
@@ -54,6 +54,8 @@ __BEGIN_DECLS
 
 typedef uint16_t in_port_t;
 
+typedef uint32_t in_addr_t;
+
 int bindresvport(int __fd, struct sockaddr_in* __sin);
 
 #if __ANDROID_API__ >= 24


### PR DESCRIPTION
Fixes a build error with crosshatch

In file included from hardware/qcom/sdm845/data/ipacfg-mgr/ipacm/src/IPACM_Main.cpp:63: In file included from hardware/qcom/sdm845/data/ipacfg-mgr/ipacm/inc/IPACM_Neighbor.h:49: In file included from hardware/qcom/sdm845/data/ipacfg-mgr/ipacm/inc/IPACM_Iface.h:50: In file included from hardware/qcom/sdm845/data/ipacfg-mgr/ipacm/inc/IPACM_Xml.h:48: out/soong/.intermediates/bionic/libc/libc.llndk/android_vendor.30_arm64_armv8-2a_kryo385_shared/gen/include/arpa/inet.h:46:1: error: unknown type name 'in_addr_t'; did you mean 'i n_addr'?
in_addr_t inet_network(const char* __s) __INTRODUCED_IN(21);

Change-Id: I3ac0ff448bbf0e9b3b5cfbaac4a86e384a3520c5